### PR TITLE
#36 display warnings about unused extra placeholders

### DIFF
--- a/email_parser/placeholder.py
+++ b/email_parser/placeholder.py
@@ -27,6 +27,10 @@ def _read_email_placeholders(email_name, src_dir):
 
 def _parse_email_placeholders(email_path):
     content = fs.read_file(email_path)
+    return parse_string_placeholders(content)
+
+
+def parse_string_placeholders(content):
     return Counter(m.group(1) for m in re.finditer(r'\{\{(\w+)\}\}', content))
 
 


### PR DESCRIPTION
Display warning when there is a placeholder in email template, which is not used in parsed email HTML/Text format

> for ex. there is a string with key `content` in the xml but there is no `{{content}}` in html template