### PR TITLE
Add {{link_locale}} param to email parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ wrap the entire block in `[[text]]`, for example `<string name="link">[[www.goog
 This is true only for entire blocks of text (paragraphs separated by blanck lines), `<string name="link">[[www.google.pl]] hello</string>`
 would be rendered as `[[www.google.pl]] hello`
 
+#### Link locale
+
+`{link_locale}` is special placeholder, which is resolved by mapping located in `src/link_locale_mappings.json` during rendering.
+If email locale couldn't be mapped to link locale, it's `en` by default.
+
+```
+{
+  "email locale": "link locale",
+  "zh-TW-Hant": "zh"
+}
+```
+If email locale will be `zh-TW-Hant`, then `[something](https://getkeepsafe.com/?locale={link_locale})` will be rendered as `[something](https://getkeepsafe.com/?locale=zh)`.
+
+
 #### Base url for images
 
 The parser will automatically add base_url to any image tag in markdown, so `![Alt text](/path/to/img.jpg)` and base url `base_url`
@@ -145,7 +159,7 @@ The file is a mapping of name to required placeholders and the number of times t
 }
 ```
 
-You can generate the file in the provided source directory from existing emails with 
+You can generate the file in the provided source directory from existing emails with
 
 ```
 $ ks-email-parser config placeholders

--- a/email_parser/__init__.py
+++ b/email_parser/__init__.py
@@ -67,7 +67,6 @@ def _parse_emails(settings):
         shutil.rmtree(settings.destination, ignore_errors=True)
 
     link_locale_mappings = reader.read_link_locale_mappings(settings)
-    logger.debug(link_locale_mappings)
     if not link_locale_mappings and not settings.force:
         return False
 

--- a/email_parser/clients.py
+++ b/email_parser/clients.py
@@ -26,13 +26,14 @@ class CustomerIoClient(object):
         return content
 
     def parse(self, email_name, settings):
+        link_locale_mappings = reader.read_link_locale_mappings(settings)
         emails = fs.email(settings.source, settings.pattern, email_name)
         subject, text, html, last_email = '', '', '', None
         for email in emails:
             logger.info('parsing email %s locale %s', email.name, email.locale)
             template, placeholders, ignored_plceholder_names = reader.read(email, settings)
             email_subjects, email_text, email_html = renderer.render(
-                email, template, placeholders, ignored_plceholder_names, settings)
+                email, template, placeholders, ignored_plceholder_names, link_locale_mappings, settings)
             subject = self._append_content(email.locale, subject, email_subjects[0])
             text = self._append_content(email.locale, text, email_text)
             html = self._append_content(email.locale, html, email_html)

--- a/email_parser/reader.py
+++ b/email_parser/reader.py
@@ -3,10 +3,13 @@ Extracts email information from an email file.
 """
 
 import logging
+import json
 import re
 from collections import namedtuple, OrderedDict
 from xml.etree import ElementTree
 from . import fs
+
+LINK_LOCALE_MAPPINGS_FILENAME = 'link_locale_mappings.json'
 
 SEGMENT_REGEX = r'\<string[^>]*>'
 SEGMENT_NAME_REGEX = r' name="([^"]+)"'
@@ -156,3 +159,13 @@ def read(email, settings):
     ordered_placeholders = _ordered_placeholders(template.placeholders_order, placeholders)
 
     return template, ordered_placeholders, ignored_plceholder_names
+
+
+def read_link_locale_mappings(settings):
+    try:
+        content = fs.read_file(settings.source, LINK_LOCALE_MAPPINGS_FILENAME)
+        return json.loads(content)
+    except FileNotFoundError:
+        logger.error('Link locale mapping (%s) could not be found at: %s' % (LINK_LOCALE_MAPPINGS_FILENAME,
+                                                                             settings.source))
+    return {}

--- a/email_parser/renderer.py
+++ b/email_parser/renderer.py
@@ -50,7 +50,6 @@ class HtmlRenderer(object):
     def __init__(self, template, link_locale_mappings, email, settings):
         self.template = template
         self.settings = settings
-        # self.link_locale_mappings = link_locale_mappings
         self.locale = email.locale
         self.link_locale = _map_link_locale(email, link_locale_mappings)
 

--- a/tests/fixtures/customerio_email.html
+++ b/tests/fixtures/customerio_email.html
@@ -13,7 +13,7 @@
       <img alt="Alt text" src="images_base/path/to/img.jpg" />
     </p>
     <p>
-      <img alt="Alt text" src="http://path.com/to/img.jpg" />
+      <img alt="Alt text" src="http://path.com/to/en/img.jpg" />
     </p>
 </body>
 </html>

--- a/tests/fixtures/email.html
+++ b/tests/fixtures/email.html
@@ -12,7 +12,7 @@
       <img alt="Alt text" src="images_base/path/to/img.jpg" />
     </p>
     <p>
-      <img alt="Alt text" src="http://path.com/to/img.jpg" />
+      <img alt="Alt text" src="http://path.com/to/en/img.jpg" />
     </p>
 </body>
 </html>

--- a/tests/fixtures/email.rtl.html
+++ b/tests/fixtures/email.rtl.html
@@ -16,7 +16,7 @@
    <img alt="Alt text" src="images_base/path/to/img.jpg"/>
   </p>
   <p>
-   <img alt="Alt text" src="http://path.com/to/img.jpg"/>
+   <img alt="Alt text" src="http://path.com/to/en/img.jpg"/>
   </p>
  </body>
 </html>

--- a/tests/link_locale_mappings.json
+++ b/tests/link_locale_mappings.json
@@ -1,0 +1,4 @@
+{
+  "en": "en",
+  "zh-TW-Hant": "zh"
+}

--- a/tests/src/en/email.xml
+++ b/tests/src/en/email.xml
@@ -5,5 +5,5 @@
     <string name="content">Dummy content</string>
     <string name="inline">[[Dummy inline]]</string>
     <string name="image">![Alt text](/path/to/img.jpg)</string>
-    <string name="image_absolute">![Alt text](http://path.com/to/img.jpg)</string>
+    <string name="image_absolute">![Alt text](http://path.com/to/{link_locale}/img.jpg)</string>
 </resources>


### PR DESCRIPTION
#42 
> #### Link locale
> 
> `{link_locale}` is special placeholder, which is resolved by mapping located in `src/link_locale_mappings.json` during rendering.
> If email locale couldn't be mapped to link locale, it's `en` by default.
> 
> ```
> {
>   "email locale": "link locale",
>   "zh-TW-Hant": "zh"
> }
> ```
> If email locale will be `zh-TW-Hant`, then `[something](https://getkeepsafe.com/?locale={link_locale})` will be rendered as `[something](https://getkeepsafe.com/?locale=zh)`.