### PR TITLE
Fixes templates editor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ PIP=venv/bin/pip
 EI=venv/bin/easy_install
 NOSE=venv/bin/nosetests
 FLAKE=venv/bin/flake8
+EMAILS_TEMPLATES_URI=git@github.com:KeepSafe/emails.git
+EMAILS_PATH=emails
+GUI_BIN=ks-email-parser
 FLAGS=
 
 
@@ -21,6 +24,10 @@ dev:
 
 install:
 	$(PYTHON) ./setup.py install
+
+rungui:
+	test -e $(EMAILS_PATH) && echo Emails templates already cloned || git clone $(EMAILS_TEMPLATES_URI) $(EMAILS_PATH);
+	$(GUI_BIN) -s $(EMAILS_PATH)/src -d $(EMAILS_PATH)/target -t $(EMAILS_PATH)/templates_html gui
 
 flake:
 	$(FLAKE) email_parser tests

--- a/email_parser/gui/Readme.md
+++ b/email_parser/gui/Readme.md
@@ -22,6 +22,8 @@ The goal is to provide a friendlier interface to make it somewhat easier to gene
 `ks-email-parser gui` in root folder.  This will (by default) fire up a local HTTP server on port 8080.  You should
 then visit <http://localhost:8080> in a modern web browser to interact with the app.
 
+Optionally fetch emails repo git@github.com:KeepSafe/emails.git in order to have current templates and run it with 
+specific parameters: `ks-email-parser -s emails/src -d emails/target -t emails/templates_html gui`
 
 ### Options
 

--- a/email_parser/gui/gui.py
+++ b/email_parser/gui/gui.py
@@ -575,6 +575,18 @@ class Server(object):
     def template(self, *paths, **_ignored):
         template_name = '/'.join(paths)
         template_path = os.path.join(self.settings.templates, template_name)
+
+        root_path = self.settings.source
+        available_locale_dict = {}
+        for name in sorted(os.listdir(root_path)):
+            name_path = os.path.join(root_path, name)
+            if os.path.isdir(name_path):
+                available_locale_dict[name] = name_path
+
+        extra_args = {
+            'availableLocaleDict': available_locale_dict
+        }
+
         if os.path.isdir(template_path):
             return self.edit_renderer.directory('Contents of ' + (template_name or 'template directory'),
                                                 self.settings.templates, template_name, '/template/{}'.format,
@@ -586,7 +598,8 @@ class Server(object):
             return self.edit_renderer.render_editor(
                 document.template_name,
                 document.styles,
-                actions=self._actions(document, **{TEMPLATE_PARAM_NAME: template_name}), )
+                actions=self._actions(document, **{TEMPLATE_PARAM_NAME: template_name}),
+                **extra_args)
 
     @cherrypy.expose
     def preview(self, working_name, **args):

--- a/email_parser/gui/gui.py
+++ b/email_parser/gui/gui.py
@@ -411,7 +411,8 @@ class InlineFormRenderer(GenericRenderer):
         replacer = InlineFormReplacer.make(self.settings, args, template_name)
 
         edit_html = replacer.html
-        edit_column = '<form name=\"gui-edit-content-form\">{0}</form>'.format(_get_body_content_string(edit_html).strip())
+        edit_column_tpl = '<form name=\"gui-edit-content-form\">{0}</form>'
+        edit_column = edit_column_tpl.format(_get_body_content_string(edit_html).strip())
         image_attrs = self._find_image_attrs(edit_html)
         image_filenames = self._find_images()
 
@@ -612,7 +613,10 @@ class Server(object):
         errors_list = []
         try:
             document = _extract_document(args, working_name)
-            errors_list = self.get_placeholder_validation_errors(path, document.template_name, document.styles, **document.args)
+            errors_list = self.get_placeholder_validation_errors(path,
+                                                                 document.template_name,
+                                                                 document.styles,
+                                                                 **document.args)
         except Exception as ex:
             logger.warning('Could not validate template %s' % ex)
 
@@ -737,6 +741,7 @@ class Server(object):
                 actions=[['View', '/email/{}'.format(rel_path)], ])
 
         try:
+            res = None
             create_template_action = ['Create new email', '/template/{}'.format(document.template_name)]
             res = _push_email_to_cms_service(self.settings, rel_path, email_path)
 
@@ -745,8 +750,9 @@ class Server(object):
                                                str(e),
                                                [create_template_action, ])
         except service.ServiceError as e:
-            message = 'Service respond with: Status: <code>%s</code><br/><code>%s</code><br/>' % (
-                e.status, e.text)
+            message = 'Service respond with: Status: ' \
+                      '<code>%s</code><br/><code>%s</code><br/>' % (e.status, e.text)
+            message += 'Response: <code>%s</code><br/>' if res else ''
             return self.edit_renderer.question('ERROR',
                                                message,
                                                [create_template_action, ])

--- a/email_parser/gui/gui.py
+++ b/email_parser/gui/gui.py
@@ -418,7 +418,7 @@ class InlineFormRenderer(GenericRenderer):
         replacer = InlineFormReplacer.make(self.settings, args, template_name)
 
         edit_html = replacer.html
-        edit_column = _get_body_content_string(edit_html).strip()
+        edit_column = '<form name=\"gui-edit-content-form\">{0}</form>'.format(_get_body_content_string(edit_html).strip())
         image_attrs = self._find_image_attrs(edit_html)
         image_filenames = self._find_images()
 
@@ -648,7 +648,7 @@ class Server(object):
             html, subject = self.final_renderer.render_email(email)
             return self.edit_renderer.question(
                 title=html_escape(subject),
-                description=_get_body_content_string(html),
+                # description=_get_body_content_string(html),
                 actions=[
                     ['Edit', '/alter/{}'.format(email_name)],
                     ['Push to repository', '/push/{}'.format(email_name)],

--- a/email_parser/gui/gui.py
+++ b/email_parser/gui/gui.py
@@ -63,6 +63,13 @@ logger.setLevel(logging.INFO)
 logger.addHandler(default_logger_handler)
 
 
+def merge_two_dicts(x, y):
+    """Given two dicts, merge them into a new dict as a shallow copy."""
+    z = x.copy()
+    z.update(y)
+    return z
+
+
 def _clean_documents():
     expired_keys = set()
     for key, value in RECENT_DOCUMENTS.items():
@@ -702,7 +709,7 @@ class Server(object):
             document.template_name,
             document.styles,
             actions=self._actions(document, **{EMAIL_PARAM_NAME: email_name}),
-            **{**extra_args, **document.args})
+            **merge_two_dicts(extra_args, document.args))
 
     @cherrypy.expose
     def saveas(self, working_name, *email_paths, **args):

--- a/email_parser/placeholder.py
+++ b/email_parser/placeholder.py
@@ -120,7 +120,7 @@ def validate_email_content(locale, name, content, src_dir=''):
         email_placeholders = parse_string_placeholders(content)
         return _validate_email_placeholders(name, locale, email_placeholders, all_placeholders)
     except FileNotFoundError:
-        # If the file does not exist skip validation
+        logger.debug('No placeholder config file found, skipping validation..')
         return True
 
 

--- a/email_parser/resources/gui/editor.html.jinja2
+++ b/email_parser/resources/gui/editor.html.jinja2
@@ -11,7 +11,7 @@
                 var incomplete_form = true;
                 var validationElem = "<li class='list-group-item list-group-item-warning'>[MSG]</li>";
 
-                function validate_placeholders() {
+                function validate_placeholders(serialized) {
                     $('#validationInfoList').empty();
                     return $.post('{{ validation_url }}', serialized, function (data) {
                         if (data.hasOwnProperty('validationErrors') && data.validationErrors.length > 0) {
@@ -53,7 +53,7 @@
                             last_serialized = serialized;
                         }, 'html').then(function () {
                             if (!incomplete_form) {
-                                validate_placeholders();
+                                validate_placeholders(serialized);
                             }
                         });
                     }
@@ -111,7 +111,7 @@
                                     formaction="{{ save_url|e }}"
                                     id="gui-submit-save"
                                     disabled="disabled">
-                                Submit
+                                Save
                             </button>
                             </div>
                         </div>

--- a/email_parser/resources/gui/editor.html.jinja2
+++ b/email_parser/resources/gui/editor.html.jinja2
@@ -54,6 +54,20 @@
                     <div class="row">
                         <div class="col-md-4 col-md-offset-4">
                             <div class="form-group">
+                                <label for="saveAsFilename">Template filename</label>
+                                <input type="text" class="form-control" name="templateFilename" id="saveAsFilename"
+                                       placeholder="Template filename"
+                                       required>
+                            </div>
+                            <div class="form-group">
+                                <label for="saveAsLocale">Template locale</label>
+                                <select multiple class="form-control" id="saveAsLocale" name="saveAsLocale" required>
+                                    {% for locale_name, locale_path in values['availableLocaleDict'].items() %}
+                                        <option value="{{ locale_path|e }}">{{ locale_name|e }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+                            <div class="form-group">
                                 <label for="cssMultipleSelect">Template style</label>
                                 <select multiple class="form-control" id="cssMultipleSelect" name="HIDDEN__styles" required>
                                     {% for style in all_styles %}

--- a/email_parser/resources/gui/editor.html.jinja2
+++ b/email_parser/resources/gui/editor.html.jinja2
@@ -79,6 +79,8 @@
                                        pattern=".+\.xml"
                                        placeholder="Template filename"
                                        aria-describedby="helpBlock2"
+                                       value="{{ values.get('templateFilename', '') }}"
+                                       readonly="{{ 'true' if values.get('templateFilename', None) else 'false'}}"
                                        required>
                                 <span id="helpBlock2" class="help-block">
                                     File name should end with <b>.xml</b> extension
@@ -86,9 +88,14 @@
                             </div>
                             <div class="form-group">
                                 <label for="localeName">Template locale</label>
-                                <select class="form-control" id="localeName" name="localePath" required>
-                                    {% for locale_name, locale_path in values['availableLocaleDict'].items() %}
-                                        <option value="{{ locale_path|e }}">{{ locale_name|e }}</option>
+                                <select class="form-control" id="localeName" name="localePath" required
+                                        readonly="{{ 'true' if values.get('localePath', None) else 'false' }}">
+                                {% for locale_name, locale_path in values['availableLocaleDict'].items() %}
+                                        <option value="{{ locale_path|e }}"
+                                                {{ 'selected' if values.get('localePath', None) == locale_name else '' }}
+                                        >
+                                        {{ locale_name|e }}
+                                        </option>
                                     {% endfor %}
                                 </select>
                             </div>

--- a/email_parser/resources/gui/editor.html.jinja2
+++ b/email_parser/resources/gui/editor.html.jinja2
@@ -2,6 +2,7 @@
     <head>
         <title>{{ title|e }}</title>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
+        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
         <script type="application/ecmascript">
             $(document).ready(function() {
                 var FINAL_INCOMPLETE_CODE = 'HIDDEN__preview_incomplete_code';
@@ -14,17 +15,26 @@
                         last_subject = this_subject;
                     }
 
-                    var this_serialized = $("#gui-form").serialize();
-                    if (this_serialized != last_serialized) {
-                        $.post('{{ view_url }}', this_serialized, function (data) {
+                    var outside_iframe_editor_contents = $("#gui-form").serialize();
+                    var serialized = outside_iframe_editor_contents;
+                    try {
+                        var editor_contents = $('form', frames['gui-edit-content'].document);
+                        var serialized_editor_contents = editor_contents.serialize();
+                        serialized += '&' + serialized_editor_contents;
+                    } catch (ex) {
+                        console.log('No iframe gui-edit-content', ex);
+                    }
+                    console.log('SER', serialized);
+                    if (serialized != last_serialized) {
+                        $.post('{{ view_url }}', serialized, function (data) {
                             console.log(data);
                             if (data.indexOf(FINAL_INCOMPLETE_CODE) >= 0) {
                                 $("#gui-submit-save").attr('disabled', 'disabled');
                             } else {
                                 $("#gui-submit-save").removeAttr('disabled');
                             }
-                            $("#gui-view-content").html(data);
-                            last_serialized = this_serialized;
+                            $("#gui-view-content").attr("srcdoc", data);
+                            last_serialized = serialized;
                         }, 'html');
                     }
                 };
@@ -35,77 +45,113 @@
         <style type="text/css">
             input.absent {border-size: 4px; border-color: #ff4444;}
         </style>
+        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css" integrity="sha512-dTfge/zgoMYpP7QbHy4gWMEGsbsdZeCXz7irItjcC3sPUFtf0kuFbDz/ixG7ArTxmDjLXDmezHubeNikyKGVyQ==" crossorigin="anonymous">
     </head>
     <body>
-        <form id="gui-form" method="POST">
-            <table>
-                <tr>
-                    <td id="gui-edit-styles" valign="top" colspan="2">
-                        <fieldset><select multiple class="{{ 'present' if styles else 'absent' }}" name="HIDDEN__styles">
-                        {% for style in all_styles %}
-                            <option {{ 'selected' if style in styles else '' }} value="{{ style|e }}">{{ style|e }}</option>
-                        {% endfor %}
-                        </select></fieldset>
-                    </td>
-                </tr>
-                <tr>
-                    <td id="gui-edit-subject">
-                        <fieldset class="gui-edit-subject">
-                            <label>Subject:
-                                <input type="text"
-                                       name="subject"
-                                       placeholder="Type subject here"
-                                       value="{{ subject|e }}"
-                                       style="width: 60%"
-                                />
-                            </label>
-                        </fieldset>
-                    </td>
-                    <td id="gui-view-subject"><h1 class="subject" style="text-align: center">{{ subject|e }}</h1></td>
-                </tr>
-                <tr>
-                    <td id="gui-editor" valign="top">
-                        <div id="gui-edit-content">{{ content }}</div>
-                    {%  if attrs %}
-                        <fieldset class="generated-fields"><ul>
-                        {% for attr in attrs %}
-                            <li><label>{{ attr }}:
-                            {% if dropdowns and attr in dropdowns %}
-                                <select name="{{ attr }}"
-                                        class="{{ 'present' if attr in values else 'absent' }}"
-                                        style="width: 60%" >
-                                {% for option in dropdowns[attr] %}
-                                    <option value="{{ option }}"
-                                        {% if values[attr] == option %} selected="selected" {% endif %}
-                                        >{% if verified_dropdowns
-                                        and verified_dropdowns[attr]
-                                        and option not in verified_dropdowns[attr] %}&#x26a0; {%  endif
-                                            %}{{ option }}</option>
-                                {% endfor %}
+        <div class="container-fluid">
+            <div class="row">
+                <form id="gui-form" method="POST">
+                    <div class="row">
+                        <div class="col-md-4 col-md-offset-4">
+                            <div class="form-group">
+                                <label for="cssMultipleSelect">Template style</label>
+                                <select multiple class="form-control" id="cssMultipleSelect" name="HIDDEN__styles" required>
+                                    {% for style in all_styles %}
+                                        <option {{ 'selected' if style in styles else '' }} value="{{ style|e }}">{{ style|e }}</option>
+                                    {% endfor %}
                                 </select>
-                            {% else %}
-                                 <input name="{{ attr }}" type="text"
-                                        class="{{ 'present' if attr in values else 'absent' }}"
-                                        placeholder="{{ attr }}"
-                                        value="{{ values[attr] }}"
-                                        style="width: 60%"
-                                 />
-                            {% endif %}
-                            </label></li>
-                        {% endfor %}
-                        </ul></fieldset>
-                    {% endif %}
-                    </td>
-                    <td id="gui-viewer" valign="top">
-                        <div id="gui-view-content"></div>
-                        <fieldset class="gui-template-actions" style="text-align: center; border-style: none">
-                            <input type="reset" value="Reset" style="font-size: large" />
-                            <input id="gui-submit-save" type="submit" value="Save" formaction="{{ save_url|e }}"
-                                   style="font-size: large" disabled="disabled" />
-                        </fieldset>
-                    </td>
-                </tr>
-            </table>
-        </form>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-2 col-md-offset-5">
+                            <div class="form-group">
+                            <input type="reset" class="btn btn-danger btn-block"/>
+                            <button type="submit"
+                                    class="btn btn-primary btn-block"
+                                    formaction="{{ save_url|e }}"
+                                    id="gui-submit-save"
+                                    disabled="disabled">
+                                Submit
+                            </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">Placeholder editor</div>
+                                <div class="panel-body">
+                                    <div class="form-group">
+                                        <label for="subjectInput">Subject</label>
+                                        <input type="text" class="form-control" name="subject" id="subjectInput"
+                                               placeholder="Type subject here" value="{{ subject|e }}" required>
+                                    </div>
+                                    <div class="row" id="gui-editor">
+                                        <div class="col-md-12">
+                                            <iframe id="gui-edit-content" name="gui-edit-content"
+                                                    srcdoc="{{ content|e}}</form>"
+                                                    frameborder="0"
+                                                    width="100%"
+                                                    height="100%"
+                                                    scrolling="auto"></iframe>
+                                        </div>
+                                        {% if attrs %}
+                                            <fieldset class="generated-fields">
+                                                <ul>
+                                                    {% for attr in attrs %}
+                                                        <li><label>{{ attr }}:
+                                                            {% if dropdowns and attr in dropdowns %}
+                                                                <select name="{{ attr }}"
+                                                                        class="{{ 'present' if attr in values else 'absent' }}"
+                                                                        style="width: 60%">
+                                                                    {% for option in dropdowns[attr] %}
+                                                                        <option value="{{ option }}"
+                                                                                {% if values[attr] == option %}
+                                                                                selected="selected" {% endif %}
+                                                                        >{% if verified_dropdowns
+                                        and verified_dropdowns[attr]
+                                        and option not in verified_dropdowns[attr] %}
+                                                                            &#x26a0; {% endif %}{{ option }}</option>
+                                                                    {% endfor %}
+                                                                </select>
+                                                            {% else %}
+                                                                <input name="{{ attr }}" type="text"
+                                                                       class="{{ 'present' if attr in values else 'absent' }}"
+                                                                       placeholder="{{ attr }}"
+                                                                       value="{{ values[attr] }}"
+                                                                       style="width: 60%"
+                                                                />
+                                                            {% endif %}
+                                                        </label></li>
+                                                    {% endfor %}
+                                                </ul>
+                                            </fieldset>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">Preview</div>
+                                <div class="panel-body">
+                                    <div class="row" id="gui-view-subject">
+                                        <h1 class="subject" style="text-align: center">{{ subject|e }}</h1>
+                                    </div>
+                                    <div class="row">
+                                        <iframe id="gui-view-content" srcdoc=""
+                                                frameborder="0"
+                                                width="100%"
+                                                height="100%"
+                                                scrolling="auto"></iframe>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
     </body>
 </html>

--- a/email_parser/resources/gui/editor.html.jinja2
+++ b/email_parser/resources/gui/editor.html.jinja2
@@ -80,8 +80,9 @@
                                        placeholder="Template filename"
                                        aria-describedby="helpBlock2"
                                        value="{{ values.get('templateFilename', '') }}"
-                                       readonly="{{ 'true' if values.get('templateFilename', None) else 'false'}}"
-                                       required>
+                                       {{ 'readonly' if values.get('templateFilename', None) else 'false'}}
+                                       required
+                                >
                                 <span id="helpBlock2" class="help-block">
                                     File name should end with <b>.xml</b> extension
                                 </span>
@@ -89,14 +90,14 @@
                             <div class="form-group">
                                 <label for="localeName">Template locale</label>
                                 <select class="form-control" id="localeName" name="localePath" required
-                                        readonly="{{ 'true' if values.get('localePath', None) else 'false' }}">
+                                        {{ 'readonly' if values.get('localePath', None) else '' }}>
                                 {% for locale_name, locale_path in values['availableLocaleDict'].items() %}
-                                        <option value="{{ locale_path|e }}"
-                                                {{ 'selected' if values.get('localePath', None) == locale_name else '' }}
-                                        >
+                                    <option value="{{ locale_path|e }}"
+                                            {{ 'selected' if values.get('localePath', None) == locale_name else '' }}
+                                    >
                                         {{ locale_name|e }}
-                                        </option>
-                                    {% endfor %}
+                                    </option>
+                                {% endfor %}
                                 </select>
                             </div>
                             <div class="form-group">

--- a/email_parser/resources/gui/editor.html.jinja2
+++ b/email_parser/resources/gui/editor.html.jinja2
@@ -8,6 +8,23 @@
                 var FINAL_INCOMPLETE_CODE = 'HIDDEN__preview_incomplete_code';
                 var last_serialized = '``````';
                 var last_subject = '``````';
+                var incomplete_form = true;
+                var validationElem = "<li class='list-group-item list-group-item-warning'>[MSG]</li>";
+
+                function validate_placeholders() {
+                    $('#validationInfoList').empty();
+                    return $.post('{{ validation_url }}', serialized, function (data) {
+                        if (data.hasOwnProperty('validationErrors') && data.validationErrors.length > 0) {
+                            data.validationErrors.forEach(function (error) {
+                                $('#validationInfoList').append(validationElem.replace('[MSG]', error))
+                            })
+                            $('#validationInfoBox').removeClass('hidden');
+                        } else {
+                            $('#validationInfoBox').addClass('hidden');
+                        }
+                    }, 'json');
+                }
+
                 var update_display = function() {
                     var this_subject = $("input[name=subject]").val();
                     if (this_subject != last_subject) {
@@ -24,18 +41,21 @@
                     } catch (ex) {
                         console.log('No iframe gui-edit-content', ex);
                     }
-                    console.log('SER', serialized);
                     if (serialized != last_serialized) {
                         $.post('{{ view_url }}', serialized, function (data) {
-                            console.log(data);
-                            if (data.indexOf(FINAL_INCOMPLETE_CODE) >= 0) {
+                            incomplete_form = data.indexOf(FINAL_INCOMPLETE_CODE) >= 0;
+                            if (incomplete_form) {
                                 $("#gui-submit-save").attr('disabled', 'disabled');
                             } else {
                                 $("#gui-submit-save").removeAttr('disabled');
                             }
                             $("#gui-view-content").attr("srcdoc", data);
                             last_serialized = serialized;
-                        }, 'html');
+                        }, 'html').then(function () {
+                            if (!incomplete_form) {
+                                validate_placeholders();
+                            }
+                        });
                     }
                 };
                 update_display();
@@ -56,12 +76,17 @@
                             <div class="form-group">
                                 <label for="saveAsFilename">Template filename</label>
                                 <input type="text" class="form-control" name="templateFilename" id="saveAsFilename"
+                                       pattern=".+\.xml"
                                        placeholder="Template filename"
+                                       aria-describedby="helpBlock2"
                                        required>
+                                <span id="helpBlock2" class="help-block">
+                                    File name should end with <b>.xml</b> extension
+                                </span>
                             </div>
                             <div class="form-group">
-                                <label for="saveAsLocale">Template locale</label>
-                                <select multiple class="form-control" id="saveAsLocale" name="saveAsLocale" required>
+                                <label for="localeName">Template locale</label>
+                                <select class="form-control" id="localeName" name="localePath" required>
                                     {% for locale_name, locale_path in values['availableLocaleDict'].items() %}
                                         <option value="{{ locale_path|e }}">{{ locale_name|e }}</option>
                                     {% endfor %}
@@ -88,6 +113,19 @@
                                     disabled="disabled">
                                 Submit
                             </button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div id="validationInfoBox" class="hidden">
+                            <div class="col-md-6 col-md-offset-3">
+                                <div class="panel panel-warning">
+                                    <div class="panel-heading">Validation warnings</div>
+                                    <div class="panel-body">
+                                        <ul class="list-group" id="validationInfoList">
+                                        </ul>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- introduces bootstrap for editor view
- simplifies new/edit view: save & push at once
- move as much editor form validation into html5
- move some validation to the JS code (though tried to avoid that)
- separates template preview within iframes
- placeholder validation is moved to separate endpoint `validation_status`